### PR TITLE
using i32 for the post_id

### DIFF
--- a/src/bin/markd.rs
+++ b/src/bin/markd.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), sqlx::Error>{
         .await
         .expect("couldn't create pool");
 
-    let row: (i64,) = sqlx::query_as("insert into myposts (post_title, post_body) values ($1, $2) returning post_id")
+    let row: (i32,) = sqlx::query_as("insert into myposts (post_title, post_body) values ($1, $2) returning post_id")
         .bind(&args[1])
         .bind(inserter)
         .fetch_one(&pool)


### PR DESCRIPTION
using i32 for the post_id was required on Windows with postgres 15.0.1 else the following error occurred: Rust type `i64` (as SQL type `INT8`) is not compatible with SQL type `INT4`